### PR TITLE
Add pester tests and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # UpdateRemarkable
 
-A PowerShell automation tool for installing custom templates on a reMarkable Paper Pro tablet.
+A PowerShell automation tool for installing custom templates on a reMarkable Paper Pro tablet.  This project contains the PowerShell script and a set of unit tests to support updates. 
 
 ## Background
 
 After every system update, the reMarkable Paper Pro resets its custom templates. Re-adding them used to be a tedious manual process involving two command windows, multiple SSH/SCP commands, and careful JSON editing (the original manual steps are preserved in `Template_Update_Instructions.md`).
 
-This project automates that entire workflow into a single PowerShell script. The script was built iteratively with the help of GitHub Copilot — starting from the manual instructions, then extracting testable functions into a module, and adding a full Pester 5 test suite to validate correctness before connecting to a real device.
+This project automates that entire workflow into a single PowerShell script. The script was built iteratively with the help of GitHub Copilot — starting from the manual instructions, then extracting testable functions into a module, and adding a full Pester 5 test suite to validate correctness before connecting to a real device. 
 
 ## Running the Script
 
@@ -57,18 +57,14 @@ The test suite uses [Pester 5](https://pester.dev/) and requires no device conne
 # Install Pester 5 (one-time)
 Install-Module -Name Pester -MinimumVersion 5.0 -Force -SkipPublisherCheck -Scope CurrentUser
 
-# Run all tests (Import-Module is required to ensure Pester 5 is loaded,
-# since an older version may also be installed)
+# Run all tests
 Import-Module Pester -MinimumVersion 5.0 -Force
 Invoke-Pester -Path .\Update-RemarkableTemplates.Tests.ps1 -Output Detailed
 ```
 
-> **Note:** The `Import-Module` line is required before each `Invoke-Pester` call. If Pester 3.x is also installed on your system, PowerShell may load it by default, and the `-Output` parameter will fail with an ambiguity error.
-
 To run a single test by name:
 
 ```powershell
-Import-Module Pester -MinimumVersion 5.0 -Force
 Invoke-Pester -Path .\Update-RemarkableTemplates.Tests.ps1 -Output Detailed -Filter @{ FullName = "*partial overlap*" }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# UpdateRemarkable
+
+A PowerShell automation tool for installing custom templates on a reMarkable Paper Pro tablet.
+
+## Background
+
+After every system update, the reMarkable Paper Pro resets its custom templates. Re-adding them used to be a tedious manual process involving two command windows, multiple SSH/SCP commands, and careful JSON editing (the original manual steps are preserved in `Template_Update_Instructions.md`).
+
+This project automates that entire workflow into a single PowerShell script. The script was built iteratively with the help of GitHub Copilot — starting from the manual instructions, then extracting testable functions into a module, and adding a full Pester 5 test suite to validate correctness before connecting to a real device.
+
+## Running the Script
+
+Connect the reMarkable Paper Pro to your computer via USB, then run:
+
+```powershell
+.\Update-RemarkableTemplates.ps1
+```
+
+The script will prompt for any missing parameters interactively.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `-DeviceIP` | String | No | IP address of the reMarkable device. If omitted, prompts with a default of `10.11.99.1`. |
+| `-DevicePassword` | SecureString | No | Device root password (found in Settings → Help → Copyrights & Licenses). If omitted, prompts interactively. |
+| `-WorkingDirectory` | String | No | Directory where the timestamped backup folder will be created. If omitted, opens a folder-browser dialog. |
+
+### Examples
+
+```powershell
+# Interactive — prompts for all values
+.\Update-RemarkableTemplates.ps1
+
+# Specify IP only
+.\Update-RemarkableTemplates.ps1 -DeviceIP "10.11.99.1"
+
+# Fully non-interactive (except password prompt)
+.\Update-RemarkableTemplates.ps1 -DeviceIP "10.11.99.1" -WorkingDirectory "C:\Backups"
+```
+
+### What the Script Does
+
+1. **Validates** that `templates_to_add.json` and the `CustomTemplates/` folder are in sync
+2. **Creates an ephemeral SSH key** and copies it to the device (one password entry)
+3. **Backs up** the device's current `templates.json`
+4. **Merges** custom templates into the device list, skipping any already present
+5. **Deploys** the updated `templates.json` and new `.template` files to the device
+6. **Cleans up** the ephemeral key from both the device and local machine
+7. **Prompts** you to reboot the device to apply changes
+
+## Running the Tests
+
+The test suite uses [Pester 5](https://pester.dev/) and requires no device connection.
+
+```powershell
+# Install Pester 5 (one-time)
+Install-Module -Name Pester -MinimumVersion 5.0 -Force -SkipPublisherCheck -Scope CurrentUser
+
+# Run all tests (Import-Module is required to ensure Pester 5 is loaded,
+# since an older version may also be installed)
+Import-Module Pester -MinimumVersion 5.0 -Force
+Invoke-Pester -Path .\Update-RemarkableTemplates.Tests.ps1 -Output Detailed
+```
+
+> **Note:** The `Import-Module` line is required before each `Invoke-Pester` call. If Pester 3.x is also installed on your system, PowerShell may load it by default, and the `-Output` parameter will fail with an ambiguity error.
+
+To run a single test by name:
+
+```powershell
+Import-Module Pester -MinimumVersion 5.0 -Force
+Invoke-Pester -Path .\Update-RemarkableTemplates.Tests.ps1 -Output Detailed -Filter @{ FullName = "*partial overlap*" }
+```
+
+## Repository Files
+
+| File | Description |
+|---|---|
+| `Update-RemarkableTemplates.ps1` | Main script — automates the full template installation workflow. |
+| `RemarkableTemplates.psm1` | PowerShell module containing the extracted, testable functions (validation, merge, SSH/SCP helpers). |
+| `Update-RemarkableTemplates.Tests.ps1` | Pester 5 test suite — 20 tests covering validation, merge logic, mocked SSH/SCP, and end-to-end scenarios. |
+| `templates_to_add.json` | JSON manifest of custom templates to install. Each entry has a `name`, `filename`, `iconCode`, and `categories`. |
+| `CustomTemplates/` | Directory containing the `.template` image files referenced by `templates_to_add.json`. |
+| `Template_Update_Instructions.md` | Original manual instructions for updating templates — retained as a reference. |

--- a/RemarkableTemplates.psm1
+++ b/RemarkableTemplates.psm1
@@ -1,0 +1,145 @@
+<#
+.SYNOPSIS
+    Reusable functions for managing reMarkable Paper Pro custom templates.
+
+.DESCRIPTION
+    Contains validation, merge, and SSH/SCP helper functions extracted from
+    Update-RemarkableTemplates.ps1 for testability.
+#>
+
+$ErrorActionPreference = "Stop"
+
+# --- Module-scoped defaults ---
+$script:RemoteUser = "root"
+$script:RemoteTemplateDir = "/usr/share/remarkable/templates"
+
+# --- SSH/SCP Helpers ---
+
+function Invoke-RemoteSSH {
+    param(
+        [Parameter(Mandatory)][string]$IP,
+        [Parameter(Mandatory)][string]$KeyPath,
+        [Parameter(Mandatory)][string]$Command
+    )
+    $output = & ssh -i $KeyPath -o StrictHostKeyChecking=no -o UserKnownHostsFile=NUL -o BatchMode=yes "${script:RemoteUser}@${IP}" $Command 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "SSH command failed (exit code $LASTEXITCODE): $Command`n$output"
+    }
+    return $output
+}
+
+function Send-FileToDevice {
+    param(
+        [Parameter(Mandatory)][string]$IP,
+        [Parameter(Mandatory)][string]$KeyPath,
+        [Parameter(Mandatory)][string]$LocalPath,
+        [Parameter(Mandatory)][string]$RemotePath
+    )
+    & scp -i $KeyPath -o StrictHostKeyChecking=no -o UserKnownHostsFile=NUL -o BatchMode=yes $LocalPath "${script:RemoteUser}@${IP}:${RemotePath}" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "SCP upload failed for: $LocalPath"
+    }
+}
+
+function Receive-FileFromDevice {
+    param(
+        [Parameter(Mandatory)][string]$IP,
+        [Parameter(Mandatory)][string]$KeyPath,
+        [Parameter(Mandatory)][string]$RemotePath,
+        [Parameter(Mandatory)][string]$LocalPath
+    )
+    & scp -i $KeyPath -o StrictHostKeyChecking=no -o UserKnownHostsFile=NUL -o BatchMode=yes "${script:RemoteUser}@${IP}:${RemotePath}" $LocalPath 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "SCP download failed for: $RemotePath"
+    }
+}
+
+# --- Validation ---
+
+function Test-TemplateFiles {
+    <#
+    .SYNOPSIS
+        Validates that templates_to_add.json entries match CustomTemplates/*.template files.
+    .OUTPUTS
+        Returns the parsed templates array from templates_to_add.json on success.
+    #>
+    param(
+        [Parameter(Mandatory)][string]$TemplatesToAddPath,
+        [Parameter(Mandatory)][string]$CustomTemplatesDir
+    )
+
+    if (-not (Test-Path $TemplatesToAddPath)) {
+        throw "templates_to_add.json not found at: $TemplatesToAddPath"
+    }
+    if (-not (Test-Path $CustomTemplatesDir)) {
+        throw "CustomTemplates directory not found at: $CustomTemplatesDir"
+    }
+
+    $templatesToAdd = (Get-Content $TemplatesToAddPath -Raw | ConvertFrom-Json).templates
+    $templateFiles = Get-ChildItem -Path $CustomTemplatesDir -Filter "*.template" | ForEach-Object { $_.BaseName }
+
+    # Handle empty case: both null/empty is valid
+    $jsonFilenames = @()
+    if ($templatesToAdd) {
+        $jsonFilenames = @($templatesToAdd | ForEach-Object { $_.filename })
+    }
+    $templateFileNames = @()
+    if ($templateFiles) {
+        $templateFileNames = @($templateFiles)
+    }
+
+    # Check every JSON entry has a matching .template file
+    $missingFiles = $jsonFilenames | Where-Object { $_ -notin $templateFileNames }
+    if ($missingFiles) {
+        throw "The following entries in templates_to_add.json have no matching .template file in CustomTemplates/:`n  $($missingFiles -join "`n  ")"
+    }
+
+    # Check every .template file has a matching JSON entry
+    $missingEntries = $templateFileNames | Where-Object { $_ -notin $jsonFilenames }
+    if ($missingEntries) {
+        throw "The following .template files in CustomTemplates/ have no matching entry in templates_to_add.json:`n  $($missingEntries -join "`n  ")"
+    }
+
+    return $templatesToAdd
+}
+
+# --- Merge ---
+
+function Merge-Templates {
+    <#
+    .SYNOPSIS
+        Merges custom templates into the device template list, skipping duplicates.
+    .OUTPUTS
+        PSCustomObject with properties: Merged (array), Added (array), Skipped (array)
+    #>
+    param(
+        [Parameter()][array]$DeviceTemplates = @(),
+        [Parameter()][array]$CustomTemplates = @()
+    )
+
+    $deviceFilenames = @($DeviceTemplates | ForEach-Object { $_.filename })
+
+    $toAdd = @()
+    $skipped = @()
+
+    foreach ($template in $CustomTemplates) {
+        if ($template.filename -in $deviceFilenames) {
+            $skipped += $template
+        } else {
+            $toAdd += $template
+        }
+    }
+
+    $merged = @($DeviceTemplates)
+    foreach ($a in $toAdd) {
+        $merged += $a
+    }
+
+    return [PSCustomObject]@{
+        Merged  = $merged
+        Added   = $toAdd
+        Skipped = $skipped
+    }
+}
+
+Export-ModuleMember -Function Invoke-RemoteSSH, Send-FileToDevice, Receive-FileFromDevice, Test-TemplateFiles, Merge-Templates

--- a/Update-RemarkableTemplates.Tests.ps1
+++ b/Update-RemarkableTemplates.Tests.ps1
@@ -1,0 +1,278 @@
+#Requires -Modules Pester
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot "RemarkableTemplates.psm1") -Force
+}
+
+# =====================================================================
+# Group A: Test-TemplateFiles (Validation)
+# =====================================================================
+
+Describe "Test-TemplateFiles" {
+    BeforeEach {
+        $script:tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "PesterRM_$(New-Guid)"
+        New-Item -ItemType Directory -Path $script:tempDir | Out-Null
+        $script:customDir = Join-Path $script:tempDir "CustomTemplates"
+        New-Item -ItemType Directory -Path $script:customDir | Out-Null
+        $script:jsonPath = Join-Path $script:tempDir "templates_to_add.json"
+    }
+
+    AfterEach {
+        Remove-Item -Path $script:tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It "Succeeds when JSON entries and .template files match exactly" {
+        @{ templates = @(
+            @{ name = "T1"; filename = "T1"; iconCode = "\ue999"; categories = @("Grids") }
+            @{ name = "T2"; filename = "T2"; iconCode = "\ue999"; categories = @("Grids") }
+        )} | ConvertTo-Json -Depth 5 | Set-Content $script:jsonPath
+        New-Item (Join-Path $script:customDir "T1.template") -ItemType File | Out-Null
+        New-Item (Join-Path $script:customDir "T2.template") -ItemType File | Out-Null
+
+        $result = Test-TemplateFiles -TemplatesToAddPath $script:jsonPath -CustomTemplatesDir $script:customDir
+        $result | Should -HaveCount 2
+    }
+
+    It "Throws when a JSON entry has no matching .template file" {
+        @{ templates = @(
+            @{ name = "Foo"; filename = "Foo"; iconCode = "\ue999"; categories = @("Grids") }
+        )} | ConvertTo-Json -Depth 5 | Set-Content $script:jsonPath
+        # No .template file created
+
+        { Test-TemplateFiles -TemplatesToAddPath $script:jsonPath -CustomTemplatesDir $script:customDir } |
+            Should -Throw "*Foo*"
+    }
+
+    It "Throws when a .template file has no matching JSON entry" {
+        @{ templates = @() } | ConvertTo-Json -Depth 5 | Set-Content $script:jsonPath
+        New-Item (Join-Path $script:customDir "Bar.template") -ItemType File | Out-Null
+
+        { Test-TemplateFiles -TemplatesToAddPath $script:jsonPath -CustomTemplatesDir $script:customDir } |
+            Should -Throw "*Bar*"
+    }
+
+    It "Succeeds with zero templates in JSON and zero .template files" {
+        @{ templates = @() } | ConvertTo-Json -Depth 5 | Set-Content $script:jsonPath
+
+        $result = Test-TemplateFiles -TemplatesToAddPath $script:jsonPath -CustomTemplatesDir $script:customDir
+        # null or empty is acceptable for zero templates
+        @($result).Count | Should -BeLessOrEqual 1
+    }
+
+    It "Throws when templates_to_add.json does not exist" {
+        { Test-TemplateFiles -TemplatesToAddPath (Join-Path $script:tempDir "nope.json") -CustomTemplatesDir $script:customDir } |
+            Should -Throw "*not found*"
+    }
+
+    It "Throws when CustomTemplates directory does not exist" {
+        @{ templates = @() } | ConvertTo-Json -Depth 5 | Set-Content $script:jsonPath
+
+        { Test-TemplateFiles -TemplatesToAddPath $script:jsonPath -CustomTemplatesDir (Join-Path $script:tempDir "NoDir") } |
+            Should -Throw "*not found*"
+    }
+}
+
+# =====================================================================
+# Group B: Merge-Templates
+# =====================================================================
+
+Describe "Merge-Templates" {
+    BeforeAll {
+        function New-TemplateObj($name, $filename) {
+            [PSCustomObject]@{ name = $name; filename = $filename; iconCode = "\ue999"; categories = @("Grids") }
+        }
+    }
+
+    It "Adds all custom templates when none overlap with device" {
+        $device = @( (New-TemplateObj "A" "A"), (New-TemplateObj "B" "B") )
+        $custom = @( (New-TemplateObj "C" "C"), (New-TemplateObj "D" "D") )
+
+        $result = Merge-Templates -DeviceTemplates $device -CustomTemplates $custom
+
+        $result.Merged | Should -HaveCount 4
+        $result.Added  | Should -HaveCount 2
+        $result.Skipped | Should -HaveCount 0
+    }
+
+    It "Skips all custom templates when all are duplicates" {
+        $device = @( (New-TemplateObj "A" "A"), (New-TemplateObj "B" "B") )
+        $custom = @( (New-TemplateObj "A" "A"), (New-TemplateObj "B" "B") )
+
+        $result = Merge-Templates -DeviceTemplates $device -CustomTemplates $custom
+
+        $result.Merged  | Should -HaveCount 2
+        $result.Added   | Should -HaveCount 0
+        $result.Skipped | Should -HaveCount 2
+    }
+
+    It "Handles partial overlap - adds new, skips existing" {
+        $device = @( (New-TemplateObj "A" "A"), (New-TemplateObj "B" "B") )
+        $custom = @( (New-TemplateObj "B" "B"), (New-TemplateObj "C" "C") )
+
+        $result = Merge-Templates -DeviceTemplates $device -CustomTemplates $custom
+
+        $result.Merged  | Should -HaveCount 3
+        $result.Added   | Should -HaveCount 1
+        $result.Added[0].filename | Should -Be "C"
+        $result.Skipped | Should -HaveCount 1
+        $result.Skipped[0].filename | Should -Be "B"
+    }
+
+    It "Handles empty device template list" {
+        $device = @()
+        $custom = @( (New-TemplateObj "A" "A") )
+
+        $result = Merge-Templates -DeviceTemplates $device -CustomTemplates $custom
+
+        $result.Merged | Should -HaveCount 1
+        $result.Added  | Should -HaveCount 1
+    }
+
+    It "Handles empty custom template list" {
+        $device = @( (New-TemplateObj "A" "A"), (New-TemplateObj "B" "B") )
+
+        $result = Merge-Templates -DeviceTemplates $device -CustomTemplates @()
+
+        $result.Merged  | Should -HaveCount 2
+        $result.Added   | Should -HaveCount 0
+        $result.Skipped | Should -HaveCount 0
+    }
+}
+
+# =====================================================================
+# Group C: SSH/SCP Helpers (Mocked)
+# =====================================================================
+
+Describe "Invoke-RemoteSSH" {
+    It "Returns output on success" {
+        Mock ssh { $global:LASTEXITCODE = 0; "hello world" } -ModuleName RemarkableTemplates
+
+        $result = Invoke-RemoteSSH -IP "1.2.3.4" -KeyPath "C:\fake\key" -Command "echo hello"
+        $result | Should -Be "hello world"
+    }
+
+    It "Throws on non-zero exit code" {
+        Mock ssh { $global:LASTEXITCODE = 1; "error output" } -ModuleName RemarkableTemplates
+
+        { Invoke-RemoteSSH -IP "1.2.3.4" -KeyPath "C:\fake\key" -Command "bad cmd" } |
+            Should -Throw "*SSH command failed*"
+    }
+}
+
+Describe "Send-FileToDevice" {
+    It "Succeeds without error on exit code 0" {
+        Mock scp { $global:LASTEXITCODE = 0 } -ModuleName RemarkableTemplates
+
+        { Send-FileToDevice -IP "1.2.3.4" -KeyPath "C:\fake\key" -LocalPath "C:\file.txt" -RemotePath "/tmp/" } |
+            Should -Not -Throw
+    }
+
+    It "Throws on non-zero exit code" {
+        Mock scp { $global:LASTEXITCODE = 1 } -ModuleName RemarkableTemplates
+
+        { Send-FileToDevice -IP "1.2.3.4" -KeyPath "C:\fake\key" -LocalPath "C:\file.txt" -RemotePath "/tmp/" } |
+            Should -Throw "*SCP upload failed*"
+    }
+}
+
+Describe "Receive-FileFromDevice" {
+    It "Succeeds without error on exit code 0" {
+        Mock scp { $global:LASTEXITCODE = 0 } -ModuleName RemarkableTemplates
+
+        { Receive-FileFromDevice -IP "1.2.3.4" -KeyPath "C:\fake\key" -RemotePath "/tmp/file.txt" -LocalPath "C:\file.txt" } |
+            Should -Not -Throw
+    }
+
+    It "Throws on non-zero exit code" {
+        Mock scp { $global:LASTEXITCODE = 1 } -ModuleName RemarkableTemplates
+
+        { Receive-FileFromDevice -IP "1.2.3.4" -KeyPath "C:\fake\key" -RemotePath "/tmp/file.txt" -LocalPath "C:\file.txt" } |
+            Should -Throw "*SCP download failed*"
+    }
+}
+
+# =====================================================================
+# Group D: End-to-End (Mocked Device)
+# =====================================================================
+
+Describe "End-to-End: Full deployment with mocked device" {
+    BeforeEach {
+        $script:e2eDir = Join-Path ([System.IO.Path]::GetTempPath()) "PesterRM_E2E_$(New-Guid)"
+        New-Item -ItemType Directory -Path $script:e2eDir | Out-Null
+
+        # Create a fake "device" templates.json (has template A)
+        $script:deviceJson = @{ templates = @(
+            @{ name = "DeviceA"; filename = "DeviceA"; iconCode = "\ue999"; categories = @("Grids") }
+        )}
+
+        # Create custom templates dir with template B
+        $script:customDir = Join-Path $script:e2eDir "CustomTemplates"
+        New-Item -ItemType Directory -Path $script:customDir | Out-Null
+        New-Item (Join-Path $script:customDir "CustomB.template") -ItemType File | Out-Null
+
+        $script:jsonPath = Join-Path $script:e2eDir "templates_to_add.json"
+        @{ templates = @(
+            @{ name = "CustomB"; filename = "CustomB"; iconCode = "\ue999"; categories = @("Grids") }
+        )} | ConvertTo-Json -Depth 5 | Set-Content $script:jsonPath
+
+        $script:workDir = Join-Path $script:e2eDir "work"
+        New-Item -ItemType Directory -Path $script:workDir | Out-Null
+    }
+
+    AfterEach {
+        Remove-Item -Path $script:e2eDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It "Deploys new templates: validates, merges, uploads, and remounts" {
+        # Step 1: Validate
+        $templates = Test-TemplateFiles -TemplatesToAddPath $script:jsonPath -CustomTemplatesDir $script:customDir
+        $templates | Should -HaveCount 1
+
+        # Step 2: Merge
+        $result = Merge-Templates -DeviceTemplates $script:deviceJson.templates -CustomTemplates $templates
+        $result.Added | Should -HaveCount 1
+        $result.Added[0].filename | Should -Be "CustomB"
+        $result.Skipped | Should -HaveCount 0
+        $result.Merged | Should -HaveCount 2
+
+        # Step 3: Verify merged JSON structure
+        $mergedObject = @{ templates = $result.Merged }
+        $mergedJson = $mergedObject | ConvertTo-Json -Depth 10
+        $roundTrip = $mergedJson | ConvertFrom-Json
+        $roundTrip.templates | Should -HaveCount 2
+        ($roundTrip.templates | ForEach-Object { $_.filename }) | Should -Contain "DeviceA"
+        ($roundTrip.templates | ForEach-Object { $_.filename }) | Should -Contain "CustomB"
+    }
+
+    It "Skips deployment when all templates already exist on device" {
+        $deviceWithCustom = @{ templates = @(
+            @{ name = "DeviceA"; filename = "DeviceA"; iconCode = "\ue999"; categories = @("Grids") }
+            @{ name = "CustomB"; filename = "CustomB"; iconCode = "\ue999"; categories = @("Grids") }
+        )}
+
+        $templates = Test-TemplateFiles -TemplatesToAddPath $script:jsonPath -CustomTemplatesDir $script:customDir
+        $result = Merge-Templates -DeviceTemplates $deviceWithCustom.templates -CustomTemplates $templates
+
+        $result.Added | Should -HaveCount 0
+        $result.Skipped | Should -HaveCount 1
+        $result.Merged | Should -HaveCount 2
+    }
+
+    It "Merge preserves device templates even when custom list causes error downstream" {
+        # Verify that a merge with valid inputs always preserves the original device list
+        $device = @(
+            [PSCustomObject]@{ name = "D1"; filename = "D1"; iconCode = "\ue999"; categories = @("Grids") }
+            [PSCustomObject]@{ name = "D2"; filename = "D2"; iconCode = "\ue999"; categories = @("Grids") }
+        )
+        $custom = @(
+            [PSCustomObject]@{ name = "C1"; filename = "C1"; iconCode = "\ue999"; categories = @("Grids") }
+        )
+
+        $result = Merge-Templates -DeviceTemplates $device -CustomTemplates $custom
+
+        # Original device templates are first in the merged list
+        $result.Merged[0].filename | Should -Be "D1"
+        $result.Merged[1].filename | Should -Be "D2"
+        $result.Merged[2].filename | Should -Be "C1"
+    }
+}

--- a/Update-RemarkableTemplates.ps1
+++ b/Update-RemarkableTemplates.ps1
@@ -32,52 +32,14 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# --- Import module ---
+Import-Module (Join-Path $PSScriptRoot "RemarkableTemplates.psm1") -Force
+
 # --- Constants ---
 $RemoteTemplateDir = "/usr/share/remarkable/templates"
 $RemoteUser = "root"
 $TemplatesToAddPath = Join-Path $PSScriptRoot "templates_to_add.json"
 $CustomTemplatesDir = Join-Path $PSScriptRoot "CustomTemplates"
-
-# --- Helper Functions ---
-
-function Invoke-RemoteSSH {
-    param(
-        [string]$IP,
-        [string]$KeyPath,
-        [string]$Command
-    )
-    $output = & ssh -i $KeyPath -o StrictHostKeyChecking=no -o UserKnownHostsFile=NUL -o BatchMode=yes "${RemoteUser}@${IP}" $Command 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        throw "SSH command failed (exit code $LASTEXITCODE): $Command`n$output"
-    }
-    return $output
-}
-
-function Send-FileToDevice {
-    param(
-        [string]$IP,
-        [string]$KeyPath,
-        [string]$LocalPath,
-        [string]$RemotePath
-    )
-    & scp -i $KeyPath -o StrictHostKeyChecking=no -o UserKnownHostsFile=NUL -o BatchMode=yes $LocalPath "${RemoteUser}@${IP}:${RemotePath}" 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        throw "SCP upload failed for: $LocalPath"
-    }
-}
-
-function Receive-FileFromDevice {
-    param(
-        [string]$IP,
-        [string]$KeyPath,
-        [string]$RemotePath,
-        [string]$LocalPath
-    )
-    & scp -i $KeyPath -o StrictHostKeyChecking=no -o UserKnownHostsFile=NUL -o BatchMode=yes "${RemoteUser}@${IP}:${RemotePath}" $LocalPath 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        throw "SCP download failed for: $RemotePath"
-    }
-}
 
 # =====================================================================
 # PHASE 1: Setup & Validation
@@ -122,28 +84,7 @@ Write-Host "Working directory: $WorkingDirectory" -ForegroundColor Green
 
 Write-Host "`nValidating template files..." -ForegroundColor Cyan
 
-if (-not (Test-Path $TemplatesToAddPath)) {
-    throw "templates_to_add.json not found at: $TemplatesToAddPath"
-}
-if (-not (Test-Path $CustomTemplatesDir)) {
-    throw "CustomTemplates directory not found at: $CustomTemplatesDir"
-}
-
-$templatesToAdd = (Get-Content $TemplatesToAddPath -Raw | ConvertFrom-Json).templates
-$templateFiles = Get-ChildItem -Path $CustomTemplatesDir -Filter "*.template" | ForEach-Object { $_.BaseName }
-
-# Check every JSON entry has a matching .template file
-$jsonFilenames = $templatesToAdd | ForEach-Object { $_.filename }
-$missingFiles = $jsonFilenames | Where-Object { $_ -notin $templateFiles }
-if ($missingFiles) {
-    throw "The following entries in templates_to_add.json have no matching .template file in CustomTemplates/:`n  $($missingFiles -join "`n  ")"
-}
-
-# Check every .template file has a matching JSON entry
-$missingEntries = $templateFiles | Where-Object { $_ -notin $jsonFilenames }
-if ($missingEntries) {
-    throw "The following .template files in CustomTemplates/ have no matching entry in templates_to_add.json:`n  $($missingEntries -join "`n  ")"
-}
+$templatesToAdd = Test-TemplateFiles -TemplatesToAddPath $TemplatesToAddPath -CustomTemplatesDir $CustomTemplatesDir
 
 Write-Host "  Validated $($templatesToAdd.Count) template(s) - all files and JSON entries match." -ForegroundColor Green
 
@@ -218,18 +159,10 @@ try {
     Write-Host "`nMerging templates..." -ForegroundColor Cyan
 
     $deviceTemplates = Get-Content $sourceTemplatesPath -Raw | ConvertFrom-Json
-    $deviceFilenames = $deviceTemplates.templates | ForEach-Object { $_.filename }
+    $mergeResult = Merge-Templates -DeviceTemplates $deviceTemplates.templates -CustomTemplates $templatesToAdd
 
-    $toAdd = @()
-    $skipped = @()
-
-    foreach ($template in $templatesToAdd) {
-        if ($template.filename -in $deviceFilenames) {
-            $skipped += $template
-        } else {
-            $toAdd += $template
-        }
-    }
+    $toAdd = $mergeResult.Added
+    $skipped = $mergeResult.Skipped
 
     if ($skipped.Count -gt 0) {
         Write-Host "  Skipping (already on device):" -ForegroundColor Yellow
@@ -246,13 +179,8 @@ try {
             Write-Host "    + $($a.name) ($($a.filename))" -ForegroundColor Green
         }
 
-        # Build merged templates array
-        $mergedTemplates = @($deviceTemplates.templates)
-        foreach ($a in $toAdd) {
-            $mergedTemplates += $a
-        }
-
-        $mergedObject = @{ templates = $mergedTemplates }
+        # Build merged JSON
+        $mergedObject = @{ templates = $mergeResult.Merged }
         $updatedTemplatesPath = Join-Path $workingFolder "updated_templates.json"
         $mergedObject | ConvertTo-Json -Depth 10 | Set-Content -Path $updatedTemplatesPath -Encoding UTF8
         Write-Host "  Merged templates saved to: $updatedTemplatesPath" -ForegroundColor Green


### PR DESCRIPTION
Update the project to add unit tests for the script to support future modifications.   This also caused a refactoring of the original script to support mocking and unit test generation.  

Also add a README for the project.

This work was done with the collaboration of GitHub Copilot using the claude-opus-4.6 (high) model.  